### PR TITLE
Fixing the vertical position of a card image.

### DIFF
--- a/scripts/card_builder.js
+++ b/scripts/card_builder.js
@@ -25,7 +25,7 @@ function get_large_card(card, callback)
 		name_size = 121;
 		ctx.drawImage(elements.background,0,0,160,220);
 		if(elements.card.image != null) {
-		        ctx.drawImage(elements.image,0,0,elements.image.width*148/150,elements.image.height*120/150,6,24,148,120);
+		        ctx.drawImage(elements.image,0,12,elements.image.width*148/150,elements.image.height*120/150,6,24,148,120);
 
 		}
 		ctx.drawImage(elements.icon,7,2,24,24);


### PR DESCRIPTION
The diff is pretty self-explanatory.  I tested some different positions and it appears that adjusting the card image down by 12 pixels produces the closest result to the actual in-game images.

Here is what is generated by my fix.
![infantry_00](https://f.cloud.github.com/assets/2695225/1061729/ac427878-11fc-11e3-92cb-1c406b3e83a2.png)

Here is the version currently on http://purei.github.io/tyrant-card-builder
![infantry_01](https://f.cloud.github.com/assets/2695225/1061731/e1c279f8-11fc-11e3-88f5-a7daf7e29595.png)

Here is the in game screenshot I took.
![infantry_02](https://f.cloud.github.com/assets/2695225/1061735/4894a34a-11fd-11e3-9d7e-b8df40e25a9a.png)

And side by side for better comparison.
![infantry_00](https://f.cloud.github.com/assets/2695225/1061729/ac427878-11fc-11e3-92cb-1c406b3e83a2.png) ![infantry_01](https://f.cloud.github.com/assets/2695225/1061731/e1c279f8-11fc-11e3-88f5-a7daf7e29595.png) ![infantry_02](https://f.cloud.github.com/assets/2695225/1061735/4894a34a-11fd-11e3-9d7e-b8df40e25a9a.png)
